### PR TITLE
feat(key): pad keys up to the nearest 16/24/32 byte

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import (
   "github.com/blaskovicz/go-cryptkeeper"
 )
 
-// set key to be used for encryption to a 16, 24, or 32 byte value
+// set key to be used for encryption. Must be <= 32 bytes
 err := cryptkeeper.SetCryptKey([]byte("12345678901234567890123456789012"))
 if err != nil {
   panic(err)

--- a/cryptkeeper.go
+++ b/cryptkeeper.go
@@ -1,6 +1,7 @@
 package cryptkeeper
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -146,7 +147,10 @@ func (cb CryptBytes) Value() (value driver.Value, err error) {
 func SetCryptKey(secretKey []byte) error {
 	keyLen := len(secretKey)
 	if keyLen != 16 && keyLen != 24 && keyLen != 32 {
-		return fmt.Errorf("Invalid KEY to set for CRYPT_KEEPER_KEY; must be 16, 24, or 32 bytes (got %d)", keyLen)
+		var err error
+		if secretKey, err = pkcs7Pad(secretKey); err != nil {
+			return err
+		}
 	}
 	cryptKeeperKey = secretKey
 	return nil
@@ -154,7 +158,14 @@ func SetCryptKey(secretKey []byte) error {
 
 // CryptKey will return the current key that will be used for encryption and decryption
 func CryptKey() []byte {
-	return cryptKeeperKey
+	if cryptKeeperKey == nil {
+		return cryptKeeperKey
+	}
+	key, err := pkcs7Unpad(cryptKeeperKey)
+	if err != nil {
+		panic("bug")
+	}
+	return key
 }
 
 // Encrypt will AES-encrypt and base64 url-encode the given string
@@ -222,4 +233,58 @@ func DecryptBytes(encrypted []byte) ([]byte, error) {
 	cipher.NewCFBDecrypter(block, iv).XORKeyStream(encrypted, encrypted)
 
 	return encrypted, nil
+}
+
+// pkcs7pad pads b to the nearest 16, 24 or 32 byte
+func pkcs7Pad(b []byte) ([]byte, error) {
+	if len(b) == 0 {
+		return nil, fmt.Errorf("invalid KEY")
+	}
+
+	blockSize := getBlockSize(len(b))
+	if blockSize == -1 {
+		return nil, fmt.Errorf("Invalid KEY to set for CRYPT_KEEPER_KEY; must be <= 32 bytes (got %d)", len(b))
+	}
+
+	n := blockSize - (len(b) % blockSize)
+	out := make([]byte, blockSize)
+	copy(out, b)
+	copy(out[len(b):], bytes.Repeat([]byte{byte(n)}, n))
+	return out, nil
+}
+
+func pkcs7Unpad(b []byte) ([]byte, error) {
+	if len(b) == 0 {
+		return nil, fmt.Errorf("Invalid KEY. Must be at least 1 byte (got %d)", len(b))
+	}
+
+	blockSize := getBlockSize(len(b))
+	if blockSize == -1 {
+		return nil, fmt.Errorf("Invalid KEY. Must be <= 32 bytes (got %d)", len(b))
+	}
+
+	c := b[len(b)-1]
+	n := int(c)
+	if n == 0 || n > len(b) {
+		return nil, fmt.Errorf("Invalid PKCS7 padding in KEY")
+	}
+
+	for i := 0; i < n; i++ {
+		if b[len(b)-n+i] != c {
+			return nil, fmt.Errorf("Invalid PKCS7 padding in KEY")
+		}
+	}
+	return b[:len(b)-n], nil
+}
+
+func getBlockSize(n int) int {
+	if n <= 16 {
+		return 16
+	} else if n <= 24 {
+		return 24
+	} else if n <= 32 {
+		return 32
+	} else {
+		return -1
+	}
 }

--- a/cryptkeeper_test.go
+++ b/cryptkeeper_test.go
@@ -28,22 +28,23 @@ func TestCryptSetup(t *testing.T) {
 	})
 }
 
-func TestCryptString(t *testing.T) {
-
-	t.Run("Invalid without SetCryptKey", func(t *testing.T) {
-		t.Run("Invalid Encrypt", func(t *testing.T) {
-			_, err := Encrypt("abc")
-			if err == nil {
-				t.Fatalf("Encrypt without SetCryptKey should have errored")
-			}
-		})
-		t.Run("Invalid Decrypt", func(t *testing.T) {
-			_, err := Decrypt("2tHq4GL8r7tTvfk6l2TS8d5nVDXY6ztqz6WTmbmq8ZOJ")
-			if err == nil {
-				t.Fatalf("Decrypt without SetCryptKey should have errored")
-			}
-		})
+func TestInvalidCrpytKey(t *testing.T) {
+	cryptKeeperKey = nil
+	t.Run("Invalid Encrypt", func(t *testing.T) {
+		_, err := Encrypt("abc")
+		if err == nil {
+			t.Fatalf("Encrypt without SetCryptKey should have errored")
+		}
 	})
+	t.Run("Invalid Decrypt", func(t *testing.T) {
+		_, err := Decrypt("2tHq4GL8r7tTvfk6l2TS8d5nVDXY6ztqz6WTmbmq8ZOJ")
+		if err == nil {
+			t.Fatalf("Decrypt without SetCryptKey should have errored")
+		}
+	})
+}
+
+func TestCryptString(t *testing.T) {
 	t.Run("Encrypt/Valid", func(t *testing.T) {
 		err := SetCryptKey([]byte("12345678901234567890123456789012"))
 		if err != nil {

--- a/cryptkeeper_test.go
+++ b/cryptkeeper_test.go
@@ -15,12 +15,15 @@ func TestCryptSetup(t *testing.T) {
 	})
 	t.Run("Valid Crypt Key Required", func(t *testing.T) {
 		err := SetCryptKey([]byte("123"))
-		if err == nil {
-			t.Fatalf("SetCryptKey should have returned an error")
+		if err != nil {
+			t.Fatalf("SetCryptKey should be valid, got: %v", err)
 		}
 		key := CryptKey()
-		if key != nil {
-			t.Fatalf("Crypt key should have been nil")
+		if key == nil {
+			t.Fatalf("Crypt key should not be nil")
+		}
+		if len(key) != 3 {
+			t.Fatalf("Crpyt key should not include padding. Got %d bytes", len(key))
 		}
 	})
 }


### PR DESCRIPTION
via PKCS#7 padding.

I guess the user can do this themselves. So this is more of a convenience.
Caveat: if this is merged, we'll be locked into a given padding algorithm. Any change in padding would require a new incompatible API.